### PR TITLE
German translation of sentences

### DIFF
--- a/custom_sentences/de/music_assistant_PlayMediaAssist.yaml
+++ b/custom_sentences/de/music_assistant_PlayMediaAssist.yaml
@@ -1,0 +1,85 @@
+language: "de"
+intents:
+  MassPlayMediaAssist:
+    data:
+
+      # TARGET AN AREA
+      - sentences:
+          - "<play> <artist> {artist} im <area>[ ab] [mit {radio_mode}]"
+          - "<play> <album> {album} [(von|vom) <artist> {artist}] im <area>[ ab] [mit {radio_mode}]"
+          - "<play> <track> {track} [(von|vom) <artist> {artist}] im <area>[ ab] [mit {radio_mode}]"
+          - "<play> <playlist> {playlist} im <area>[ ab] [mit {radio_mode}]"
+          - "<play> <radio_station> {radio} im <area>[ ab]"
+        expansion_rules:
+          play: "(spiel|spiele)"
+          artist: "[den|die|der] (Künstler|Interpreten|Band|Gruppe)"
+          track: "[den|das] (Titel|Song|Lied)"
+          album: "[das|die] (Album|EP|Platte|Kompilation|Single)"
+          playlist: "[die] Playlist"
+          radio_station: "[den|das|die] (Radiosender|Radio|Sender)"
+
+      # TARGET A NAME
+      - sentences:
+          - "<play> <artist> {artist} auf [dem ]{name} [<player_devices>][ ab] [mit {radio_mode}]"
+          - "<play> <album> {album} [(von|vom) <artist> {artist}] auf [dem ]{name} [<player_devices>][ ab] [mit {radio_mode}]"
+          - "<play> <track> {track} [(von|vom) <artist> {artist}] auf [dem ]{name} [<player_devices>][ ab] [mit {radio_mode}]"
+          - "<play> <playlist> {playlist} auf [dem ]{name} [<player_devices>][ ab] [mit {radio_mode}]"
+          - "<play> <radio_station> {radio} auf [dem ]{name} [<player_devices>][ ab]"
+        expansion_rules:
+          play: "(spiel|spiele)"
+          artist: "[den|die] (Künstler|Interpreten|Band|Gruppe)"
+          track: "[den|das] (Titel|Song|Lied)"
+          album: "[das|die] (Album|EP|Platte|Kompilation|Single)"
+          playlist: "[die] Playlist"
+          radio_station: "[den|das|die] (Radiosender|Radio|Sender)"
+          player_devices: "(Lautsprecher|[media ]player|[bluetooth ]box)"
+        requires_context:
+          domain: "media_player"
+
+      # TARGET AN AREA AND A NAME
+      - sentences:
+          - "<play> <artist> {artist} im <area> auf [dem ]{name} [<player_devices>][ ab] [mit {radio_mode}]"
+          - "<play> <album> {album} [(von|vom) <artist> {artist}] im <area> auf [dem ]{name} [<player_devices>][ ab] [mit {radio_mode}]"
+          - "<play> <track> {track} [(von|vom) <artist> {artist}] im <area> auf [dem ]{name}[ ab] [<player_devices>][mit {radio_mode}]"
+          - "<play> <playlist> {playlist} im <area> auf [dem ]{name}[ ab] [<player_devices>][mit {radio_mode}]"
+          - "<play> <radio_station> {radio} im <area> auf [dem ]{name}[ ab] [<player_devices>]"
+        expansion_rules:
+          play: "(spiel|spiele)"
+          artist: "[den|die] (Künstler|Interpreten|Band|Gruppe)"
+          track: "[den|das] (Titel|Song|Lied)"
+          album: "[das|die] (Album|EP|Platte|Kompilation|Single)"
+          playlist: "[die] Playlist"
+          radio_station: "[den|das|die] (Radiosender|Radio|Sender)"
+          player_devices: "(Lautsprecher|[media ]player|[bluetooth ]box)"
+
+      # CONTEXT AWARNESS
+      - sentences:
+          - "<play> <artist> {artist}[ ab] [mit {radio_mode}]"
+          - "<play> <album> {album} [(von|vom) <artist> {artist}][ ab] [mit {radio_mode}]"
+          - "<play> <track> {track} [(von|vom) <artist> {artist}][ ab] [mit {radio_mode}]"
+          - "<play> <playlist> {playlist}[ ab] [mit {radio_mode}]"
+          - "<play> <radio_station> {radio}[ ab]"
+        expansion_rules:
+          play: "(spiel|spiele)"
+          artist: "[den|der»die] (Künstler|Interpreten|Band|Gruppe)"
+          track: "[den|das] (Titel|Song|Lied)"
+          album: "[das|die] (Album|EP|Platte|Kompilation|Single)"
+          playlist: "[die] Playlist"
+          radio_station: "[den|das|die] (Radiosender|Radio|Sender)"
+        requires_context:
+          area:
+            slot: true
+lists:
+  artist:
+    wildcard: true
+  album:
+    wildcard: true
+  track:
+    wildcard: true
+  playlist:
+    wildcard: true
+  radio:
+    wildcard: true
+  radio_mode:
+    values:
+      - "radio mode"

--- a/custom_sentences/de/responses.yaml
+++ b/custom_sentences/de/responses.yaml
@@ -1,4 +1,4 @@
-language: "en"
+language: "de"
 responses:
   intents:
     MassPlayMediaAssist:

--- a/custom_sentences/de/responses.yaml
+++ b/custom_sentences/de/responses.yaml
@@ -1,0 +1,5 @@
+language: "en"
+responses:
+  intents:
+    MassPlayMediaAssist:
+      default: "Okay"


### PR DESCRIPTION
This is a German translation of the sentences of the original English file. Assist picks up some I've tested manually and works as expected (except for https://github.com/music-assistant/hass-music-assistant/issues/3271 ).

I'm not sure what `((...)|(...))` (e.g. in `play: "((play)|(listen to))"`) does in comparison to `(...|...)` and sticked to the letter one in the German translation.

Is there any tool that can check for syntax (sentences, not yaml) and produce all the possible combinations? Just in case I've got something wrong...